### PR TITLE
Makes RTF handle plaintext documents.

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -27,6 +27,7 @@ repositories {
 
 def junitVersion = '5.3.1'
 def slf4jVersion = '1.7.26'
+def jaxbVersion = '2.3.2'
 
 dependencies {
     implementation group: 'org.jetbrains', name: 'annotations', version: '17.0.0'
@@ -35,6 +36,9 @@ dependencies {
     implementation group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion
     implementation group: 'edu.umn.nlpie', name: 'nlpnewt', version: '[0.0, )'
 
+    implementation group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: jaxbVersion
+
+    runtimeOnly group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: jaxbVersion
     runtimeOnly group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.11.2'
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: junitVersion
@@ -52,7 +56,7 @@ task fatJar(type: Jar) {
                 'Implementation-Version': version,
                 'Main-Class': 'edu.umn.nlpnewt.Newt'
     }
-    baseName = project.name + '-all'
+    setArchiveBaseName project.name + '-all'
     from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar
 }

--- a/java/src/test/java/edu/umn/biomedicus/rtf/RtfProcessorTest.java
+++ b/java/src/test/java/edu/umn/biomedicus/rtf/RtfProcessorTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Regents of the University of Minnesota
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.umn.biomedicus.rtf;
+
+import edu.umn.nlpnewt.Document;
+import edu.umn.nlpnewt.Event;
+import edu.umn.nlpnewt.JsonObjectImpl;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RtfProcessorTest {
+  @Test
+  void rtfDocument() throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream("edu/umn/biomedicus/rtf/test.rtf")) {
+      int b;
+      while ((b = is.read()) != -1) {
+        baos.write(b);
+      }
+    }
+    Event event = Event.create("1");
+    event.getBinaryData().put("rtf", baos.toByteArray());
+    RtfProcessor processor = new RtfProcessor();
+    processor.process(event, JsonObjectImpl.newBuilder().build(), JsonObjectImpl.newBuilder());
+    Document plaintext = event.getDocuments().get("plaintext");
+    assertEquals("The quick brown fox jumped over the lazy dog.\n", plaintext.getText());
+  }
+
+  @Test
+  void plaintextDocument() {
+    Event event = Event.create("1");
+    event.getBinaryData().put("rtf", "The quick brown fox jumped over the lazy dog.\n".getBytes());
+    RtfProcessor processor = new RtfProcessor();
+    processor.process(event, JsonObjectImpl.newBuilder().build(), JsonObjectImpl.newBuilder());
+    Document plaintext = event.getDocuments().get("plaintext");
+    assertEquals("The quick brown fox jumped over the lazy dog.\n", plaintext.getText());
+  }
+}

--- a/java/src/test/java/edu/umn/biomedicus/rtf/beans/keywords/PropertyKeywordActionTest.java
+++ b/java/src/test/java/edu/umn/biomedicus/rtf/beans/keywords/PropertyKeywordActionTest.java
@@ -24,6 +24,7 @@ class PropertyKeywordActionTest {
     HashMap<String, Integer> map = new HashMap<>();
     map.put("bar", 0);
     state = new RtfState(Collections.singletonMap("foo", map));
+    state.setDestination("Rtf");
     sink = mock(RtfSink.class);
   }
 
@@ -40,7 +41,7 @@ class PropertyKeywordActionTest {
     RtfSource source = new RtfSource(null);
     action.setParameter(4);
     action.executeAction(state, source, sink);
-    verify(sink).propertyChanged(, "foo", "bar", 0, 4);
+    verify(sink).propertyChanged("Rtf", "foo", "bar", 0, 4);
     assertEquals(4, state.getPropertyValue("foo", "bar"));
   }
 
@@ -57,7 +58,7 @@ class PropertyKeywordActionTest {
     RtfSource source = new RtfSource(null);
     action.setParameter(4);
     action.executeAction(state, source, sink);
-    verify(sink).propertyChanged(, "foo", "bar", 0, 1);
+    verify(sink).propertyChanged("Rtf", "foo", "bar", 0, 1);
     assertEquals(1, state.getPropertyValue("foo", "bar"));
   }
 
@@ -92,7 +93,7 @@ class PropertyKeywordActionTest {
     RtfSource source = new RtfSource(null);
     action.setParameter(null);
     action.executeAction(state, source, sink);
-    verify(sink).propertyChanged(, "foo", "bar", 0, 1);
+    verify(sink).propertyChanged("Rtf", "foo", "bar", 0, 1);
     assertEquals(1, state.getPropertyValue("foo", "bar"));
   }
 }

--- a/java/src/test/java/edu/umn/biomedicus/rtf/beans/keywords/PropertyResetKeywordActionTest.java
+++ b/java/src/test/java/edu/umn/biomedicus/rtf/beans/keywords/PropertyResetKeywordActionTest.java
@@ -30,14 +30,15 @@ class PropertyResetKeywordActionTest {
 
   @Test
   void resets() throws IOException {
+    state.setDestination("Rtf");
     PropertyResetKeywordAction action = new PropertyResetKeywordAction();
     action.setBegin(5);
     action.setEnd(10);
     action.setPropertyGroupName("foo");
     RtfSource source = new RtfSource(null);
     action.executeAction(state, source, sink);
-    verify(sink).propertyChanged(, "foo", "bar", 1, 0);
-    verify(sink).propertyChanged(, "foo", "baz", 2, 0);
+    verify(sink).propertyChanged("Rtf", "foo", "bar", 1, 0);
+    verify(sink).propertyChanged("Rtf", "foo", "baz", 2, 0);
     assertEquals(0, state.getPropertyValue("foo", "bar"));
     assertEquals(0, state.getPropertyValue("foo", "baz"));
   }


### PR DESCRIPTION
Resolves #10 by adding a test for the '{\rtf1' string at the start of rtf documents.

This update also adds JDK 12 support.