### PR TITLE
Fixes to the stanza dependencies

### DIFF
--- a/python/biomedicus/negation/deepen.py
+++ b/python/biomedicus/negation/deepen.py
@@ -110,6 +110,8 @@ class DeepenTagger:
                         trigger_edge = dep
                         break
                 gov = trigger_edge
+                if gov is None:
+                    raise ValueError('Dependency not found.')
                 while True:
                     if gov.head is None:
                         break

--- a/python/biomedicus/pipeline/default_pipeline.py
+++ b/python/biomedicus/pipeline/default_pipeline.py
@@ -187,7 +187,7 @@ def default_pipeline_parser():
                         help="The identifier for the serializer to use, see MTAP serializers.")
     parser.add_argument('--include-label-text', action='store_true',
                         help="Flag to include the covered text for every label")
-    parser.add_argument('--threads', default=4, type=int,
+    parser.add_argument('--threads', default=8, type=int,
                         help="The number of threads (documents being processed in parallel) "
                              "to use for processing")
     return parser


### PR DESCRIPTION
Switched the method for creating the referential dependency graph from a queue over stanza dependencies to graph construction followed by breadth-first search. Resolves #74.