### PR TITLE
CLI write_config fix

### DIFF
--- a/python/biomedicus/cli.py
+++ b/python/biomedicus/cli.py
@@ -119,7 +119,11 @@ def write_config(conf):
     config_path = conf.files[conf.config]
     name = Path(config_path).name
     if conf.path is not None:
-        output_path = str(Path(conf.path) / name)
+        output_path = Path(conf.path)
+        if output_path.is_dir():
+            output_path = str(output_path / name)
+        else:
+            output_path = str(output_path)
     else:
         output_path = str(Path.cwd() / name)
 


### PR DESCRIPTION
Will test whether the output path is a directory before appending a file name. Resolves #99 .