### PR TITLE
135 deploying rtf to text downloads models unnecessarily

### DIFF
--- a/biomedicus_client/pyproject.toml
+++ b/biomedicus_client/pyproject.toml
@@ -46,11 +46,6 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[project.optional-dependencies]
-test = [
-    "pytest==7.2.2"
-]
-
 [project.scripts]
 b9client = "biomedicus_client.cli:main"
 

--- a/python/biomedicus/deployment/rtf_to_text.py
+++ b/python/biomedicus/deployment/rtf_to_text.py
@@ -67,7 +67,7 @@ def argument_parser() -> ArgumentParser:
         help="The log level for pipeline runners."
     )
     parser.add_argument(
-        '--startup-timeout', type=float,
+        '--startup-timeout', type=float, default=10,
         help="The timeout (in seconds) for individual processor services to deploy before failure."
     )
     return parser


### PR DESCRIPTION
- Fixed a failure from missing timeout
- Removed biomedicus_client[test] optional dependencies since biomedicus_client has no tests
